### PR TITLE
fix: adjust layout and error message display for login form

### DIFF
--- a/PlanGo_frontend/src/app/auth/login/login.component.html
+++ b/PlanGo_frontend/src/app/auth/login/login.component.html
@@ -32,12 +32,12 @@
       </picture>
       <h1 class="my-6 text-l font-bold text-center">Tu puerta al mundo. Planifica, descubre y vive tu próximo destino.</h1>
       <form class="w-full" (ngSubmit)="login()">
-        <div class=" mb-4">
+        <div class=" mb-4 h-24">
           <label class="">Email</label>
           <input class="mt-2 w-full h-12 border p-2 rounded-full" type="email" [(ngModel)]="email" name="email" required>
           <p *ngIf="errorMessage" class="text-red-500 text-sm">{{ errorMessage }}</p>
         </div>
-        <div class="mb-4">
+        <div class="mb-4 h-24">
           <label class="my-2">Contraseña</label>
           <input class="mt-2 w-full h-12 border p-2 rounded-full" type="password" [(ngModel)]="password" name="password" required>
           <p *ngIf="errorMessage" class="text-red-500 text-sm">{{ errorMessage }}</p>


### PR DESCRIPTION
This pull request includes a small change to the `PlanGo_frontend/src/app/auth/login/login.component.html` file. The change adds a fixed height of `h-24` to the email and password input container `div` elements to improve layout consistency.