### PR TITLE
feat: update get_userId_by_userUid to accept POST requests and retrie…

### DIFF
--- a/PlanGo_backend/apps/users/urls.py
+++ b/PlanGo_backend/apps/users/urls.py
@@ -4,5 +4,5 @@ from apps.users.views import RegisterView, LoginWithGoogleView, get_userId_by_us
 urlpatterns = [
     path('register/', RegisterView.as_view(), name='register'),
     path('login-with-google/', LoginWithGoogleView.as_view(), name='login-with-google'),
-    path('user/get_id/<str:uid>', get_userId_by_userUid, name='get_userId_by_userUid'),
+    path('user/get_id', get_userId_by_userUid, name='get_userId_by_userUid'),
 ]

--- a/PlanGo_backend/apps/users/views.py
+++ b/PlanGo_backend/apps/users/views.py
@@ -107,12 +107,17 @@ class LoginWithGoogleView(View):
             return JsonResponse({'error': str(e)}, status=400)
        
 
-def get_userId_by_userUid(request, uid):
-    try:
-        user = User.objects.get(firebase_uid=uid)
-        return JsonResponse({'id': user.id})
-    except User.DoesNotExist:
-        return JsonResponse({'error': 'Usuario no encontrado'}, status=404)    
+@csrf_exempt
+def get_userId_by_userUid(request):
+    if request.method == 'POST':
+        data = json.loads(request.body)
+        uid = data.get('uid')
+        try:
+            user = User.objects.get(firebase_uid=uid)
+            return JsonResponse({'id': user.id})
+        except User.DoesNotExist:
+            return JsonResponse({'error': 'Usuario no encontrado'}, status=404)
+    return JsonResponse({'error': 'Método no permitido'}, status=405)
 
 
 # PARTICIPANTS

--- a/PlanGo_frontend/src/app/core/services/itineraries.service.ts
+++ b/PlanGo_frontend/src/app/core/services/itineraries.service.ts
@@ -31,7 +31,7 @@ export class ItinerariesService extends BaseHttpService {
     const uid = decodedPayload?.user_id;
     if (!uid) throw new Error('UID not found in token');
   
-    const response: any = await this.httpClient.post(`${globals.apiBaseUrl}/users/get-id/`, { uid }).toPromise();
+    const response: any = await this.httpClient.post(`${globals.apiBaseUrl}/users/user/get_id`, { uid }).toPromise();
     return response.id;
   }
 


### PR DESCRIPTION
This pull request includes changes to the `PlanGo_backend` and `PlanGo_frontend` codebases to modify the `get_userId_by_userUid` endpoint, improving its structure and ensuring consistency in its usage across the application. The most important changes include updating the URL pattern, refactoring the backend function to handle POST requests, and aligning the frontend service call with the updated endpoint.

### Backend changes:

* **Updated URL pattern**: The `get_userId_by_userUid` endpoint in `PlanGo_backend/apps/users/urls.py` was modified to remove the `<str:uid>` parameter from the URL path and simplify it to `user/get_id`.
* **Refactored backend function**: The `get_userId_by_userUid` function in `PlanGo_backend/apps/users/views.py` was updated to:
  - Use the `@csrf_exempt` decorator to allow cross-site requests.
  - Accept `uid` as part of the POST request body instead of a URL parameter.
  - Return a 405 status code for non-POST requests.

### Frontend changes:

* **Aligned service call with updated endpoint**: The `getUserIdByUid` method in `PlanGo_frontend/src/app/core/services/itineraries.service.ts` was updated to match the new backend endpoint URL (`user/get_id`) and ensure proper communication between the frontend and backend.…ve user ID from request body