### PR TITLE
Refactors endpoints and improves authentication handling

### DIFF
--- a/PlanGo_backend/apps/expenses/urls.py
+++ b/PlanGo_backend/apps/expenses/urls.py
@@ -6,7 +6,7 @@ urlpatterns = [
     path('expenses/', get_expenses, name='get_expenses'),
     path('expense/destination/<int:destination_id>/', get_expenses_by_destination, name='get_expenses_by_destination'),
     path('expenses/expense/', get_expenses_with_names, name='get_expenses_with_names'),
-    path('expenses/expense/user/', get_expenses_with_names_by_user, name='get_expenses_with_names_by_user'),
+    path('expense/user/', get_expenses_with_names_by_user, name='get_expenses_with_names_by_user'),
 
     # USER EXPENSES
     path('user-expenses/', get_user_expenses, name='get_user_expenses'),

--- a/PlanGo_backend/apps/expenses/views.py
+++ b/PlanGo_backend/apps/expenses/views.py
@@ -49,9 +49,6 @@ def get_expenses_by_destination(request, destination_id):
         }
         for i in destexpenses
     ]
-    print(destexpenses.exists())
-    print(destexpenses)
-    print(data)
     return JsonResponse({'destination expenses': data})
         
     
@@ -179,10 +176,12 @@ def get_expenses_with_names(request):
     return JsonResponse({'expenses': serializer.data})
 
 
-@api_view(['GET'])
-@permission_classes([IsAuthenticated])
+# @api_view(['GET'])
+# @permission_classes([IsAuthenticated])
 def get_expenses_with_names_by_user(request):
     user = request.user
+    if not user or not user.is_authenticated:
+        return JsonResponse({'error': 'Usuario no autenticado'}, status=401)
     expenses = Expense.objects.filter(paid_by_user=user)
     serializer = ExpenseWithNamesSerializer(expenses, many=True)
     return JsonResponse({'expenses': serializer.data})

--- a/PlanGo_backend/apps/itineraries/views.py
+++ b/PlanGo_backend/apps/itineraries/views.py
@@ -99,7 +99,8 @@ def get_destinations(request):
         return JsonResponse({'error': 'No hay destinos creados'}, status=404)
     data = [
         {
-            'itinerary_id': i.itinerary.itinerary_id if hasattr(i.itinerary, 'itinerary_id') else i.itinerary,            'country': i.country,
+            'itinerary_id': i.itinerary.itinerary_id if hasattr(i.itinerary, 'itinerary_id') else i.itinerary,            
+            'country': i.country,
             'city_name': i.city_name,
             'start_date': i.start_date,
             'end_date': i.end_date,
@@ -115,7 +116,8 @@ def get_destinations_by_itinerary(request, itinerary_id):
         return JsonResponse({'error': 'No hay destinos creados con este usuario.'}, status=404)
     data = [
         {
-            'itinerary_id': i.itinerary.itinerary_id if hasattr(i.itinerary, 'itinerary_id') else i.itinerary,            'country': i.country,
+            'itinerary_id': i.itinerary.itinerary_id if hasattr(i.itinerary, 'itinerary_id') else i.itinerary,            
+            'country': i.country,
             'city_name': i.city_name,
             'start_date': i.start_date,
             'end_date': i.end_date,

--- a/PlanGo_backend/config/settings.py
+++ b/PlanGo_backend/config/settings.py
@@ -28,6 +28,17 @@ DEBUG = True
 ALLOWED_HOSTS = []
 
 
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework.authentication.SessionAuthentication',
+        'rest_framework.authentication.BasicAuthentication',
+        # 'core.middleware.firebase_authentication.FirebaseAuthentication',  # Elimina o comenta esta línea
+    ),
+    'DEFAULT_PERMISSION_CLASSES': (
+        'rest_framework.permissions.IsAuthenticated',
+    ),
+}
+
 # Application definition
 
 INSTALLED_APPS = [
@@ -57,7 +68,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    #'core.middleware.firebase_authentication.FirebaseAuthenticationMiddleware',
+    'core.middleware.firebase_authentication.FirebaseAuthenticationMiddleware',
 ]
 
 MIDDLEWARE.insert(0, 'corsheaders.middleware.CorsMiddleware')

--- a/PlanGo_backend/core/middleware/firebase_authentication.py
+++ b/PlanGo_backend/core/middleware/firebase_authentication.py
@@ -1,4 +1,4 @@
-""" from django.utils.deprecation import MiddlewareMixin
+from django.utils.deprecation import MiddlewareMixin
 from config.firebase_config import auth
 from django.http import JsonResponse
 from django.contrib.auth import get_user_model
@@ -13,6 +13,8 @@ class FirebaseAuthenticationMiddleware(MiddlewareMixin):
 
         # Excluir rutas públicas
         public_paths = ['/users/login-with-google/', '/users/register/']
+        if request.path.startswith('/admin/'):
+            return None
         if request.path in public_paths:
             return None
 
@@ -41,4 +43,4 @@ class FirebaseAuthenticationMiddleware(MiddlewareMixin):
             request.user = user
 
         except Exception as e:
-            return JsonResponse({'error': 'Token inválido o expirado', 'detail': str(e)}, status=401) """
+            return JsonResponse({'error': 'Token inválido o expirado', 'detail': str(e)}, status=401)

--- a/PlanGo_frontend/src/app/auth/auth.service.ts
+++ b/PlanGo_frontend/src/app/auth/auth.service.ts
@@ -22,7 +22,6 @@ export class AuthService {
         headers: {
           Authorization: `Bearer ${idToken}`
         }
-        console.log("PRUEBAAAAAAAAAAAAAAAAAAAAAAAAA", headers)
       }).subscribe(
         (rs) => console.log('Perfil obtenido:', rs),
         (err) => console.error('Error al obtener perfil:', err)

--- a/PlanGo_frontend/src/app/core/services/itineraries.service.ts
+++ b/PlanGo_frontend/src/app/core/services/itineraries.service.ts
@@ -20,6 +20,7 @@ export class ItinerariesService extends BaseHttpService {
   }
 
   async getIdUser(): Promise<number> {
+  
     if (!isPlatformBrowser(this.platformId)) throw new Error('localStorage no está disponible en este entorno');
     const token = localStorage.getItem(globals.keys.accessToken) || '';
     if (!token) throw new Error('No token found in localStorage');
@@ -28,17 +29,18 @@ export class ItinerariesService extends BaseHttpService {
     if (!payloadBase64) throw new Error('Invalid token format');
   
     const decodedPayload = JSON.parse(atob(payloadBase64));
-    const uid = decodedPayload?.user_id;
+    const uid = decodedPayload?.uid || decodedPayload?.sub;
     if (!uid) throw new Error('UID not found in token');
-  
-    const response: any = await this.httpClient.post(`${globals.apiBaseUrl}/users/user/get_id`, { uid }).toPromise();
-    return response.id;
+    
+    const headers = this.createHeaders();
+    const response: any = await this.httpClient
+      .post(`${globals.apiBaseUrl}/users/user/get_id/`, { uid }, { headers })
+      .toPromise();   
+      return response.id;
   }
 
   async getItineraries(): Promise<Observable<any>> {
-    debugger
     const userId = await this.getIdUser();
-    console.log("aaaaaa", userId);
     const headers = this.createHeaders();
     return this.httpClient.get(`${globals.apiBaseUrl}/itineraries/itinerary/${userId}`, { headers });
   }

--- a/PlanGo_frontend/src/app/destinations/destinations.component.ts
+++ b/PlanGo_frontend/src/app/destinations/destinations.component.ts
@@ -19,9 +19,12 @@ export class DestinationsComponent implements OnInit {
 
   constructor(private destinationService: DestinationService) {}
 
-ngOnInit(): void {
-  this.fetchDestinationsByItinerary(1); // PRUEBA CON itinerary_id 1
-}
+  ngOnInit(): void { // La idea es que al pulsar un itinerario, recibe su id y muestra destino / destinos
+  if (this.selectedItineraryId !== null) {
+      this.fetchDestinationsByItinerary(this.selectedItineraryId);
+    }
+  }
+  
   fetchDestinationsByItinerary(itineraryId: number): void {
     this.destinationService.getDestinationsByItinerary(itineraryId).subscribe({
       next: (data: any) => {

--- a/PlanGo_frontend/src/app/itineraries/itineraries.component.ts
+++ b/PlanGo_frontend/src/app/itineraries/itineraries.component.ts
@@ -29,8 +29,8 @@ export class ItinerariesComponent implements OnInit {
           this.itineraries = data.itineraries;
         },
         error: (err: any) => {
-          console.error('Error al obtener itinerarios:', err);
           this.errorMessage = 'No se pudieron cargar los itinerarios.';
+          console.error('Error al obtener itinerarios:', err);
         },
       });
     } catch (error) {


### PR DESCRIPTION
This pull request introduces various updates across the backend and frontend of the PlanGo application. Key changes include improvements to authentication and middleware configurations, cleanup of debugging and logging code, adjustments to API endpoints, and enhancements to frontend service and component logic. Below is a categorized summary of the most important changes:

### Backend Changes

**Authentication and Middleware Updates:**
* Added `SessionAuthentication` and `BasicAuthentication` as default authentication classes in `REST_FRAMEWORK` settings, and re-enabled the `FirebaseAuthenticationMiddleware` in `PlanGo_backend/config/settings.py`. [[1]](diffhunk://#diff-704ee5ffc1b23df248e96457997b83ccc312d8ca132e01aad237adb2703edb03R31-R41) [[2]](diffhunk://#diff-704ee5ffc1b23df248e96457997b83ccc312d8ca132e01aad237adb2703edb03L60-R71)
* Updated the Firebase authentication middleware to exclude the `/admin/` path from authentication checks and removed commented-out code. [[1]](diffhunk://#diff-658a1a44b7e2034a8558c2c4d3d994515e5ae8243f248025c18e9ea553a559d9R16-R17) [[2]](diffhunk://#diff-658a1a44b7e2034a8558c2c4d3d994515e5ae8243f248025c18e9ea553a559d9L44-R46)

**API Endpoint Adjustments:**
* Modified the URL path for `get_expenses_with_names_by_user` to simplify its structure in `PlanGo_backend/apps/expenses/urls.py`.

**Code Cleanup:**
* Removed unnecessary `print` statements from `get_expenses_by_destination` in `PlanGo_backend/apps/expenses/views.py`.

### Frontend Changes

**Service Enhancements:**
* Updated `ItinerariesService` to handle token decoding more robustly by supporting both `uid` and `sub` fields, and added headers to the API request for retrieving user IDs.

**Component Logic Improvements:**
* Refined the `DestinationsComponent` to dynamically fetch destinations based on the selected itinerary ID, improving its responsiveness to user interactions.

**Code Cleanup:**
* Removed debugging logs and unnecessary `console.log` statements from `AuthService` and `ItinerariesService`. [[1]](diffhunk://#diff-4b8f2042d5971f209be7b89f39bf93ff5b05d99c7f3c867caa677cdaa6323407L25) [[2]](diffhunk://#diff-72714c17ec0b0315a6cfbdcb7cdf686fe4ae3ea302689a571e787eb333ceade4L31-L41)