### PR TITLE
Add destinations count to itineraries and update UI

### DIFF
--- a/PlanGo_backend/apps/itineraries/views.py
+++ b/PlanGo_backend/apps/itineraries/views.py
@@ -36,9 +36,11 @@ def get_itineraries(request):
             'creation_date': i.creation_date,
             'start_date': i.start_date,
             'end_date': i.end_date,
+            'destinations_count': i.destinations.count(),
         }
         for i in itineraries
     ]
+    print("PEPITO", data)
     return JsonResponse({'itineraries': data})
     
     
@@ -54,9 +56,11 @@ def get_itineraries_by_user(request, user_id):
             'creation_date': i.creation_date,
             'start_date': i.start_date,
             'end_date': i.end_date,
+            'destinations_count': i.destinations.count(),
         }
         for i in itineraries
     ]
+    print("PEPITA", data)
     return JsonResponse({'itineraries': data})
 
 

--- a/PlanGo_frontend/src/app/itineraries/interfaces/itinerary.interface.ts
+++ b/PlanGo_frontend/src/app/itineraries/interfaces/itinerary.interface.ts
@@ -5,4 +5,5 @@ export interface Itinerary {
     creation_date: string;
     start_date: Date;
     end_date: Date;
-  }
+    destinations_count?: number;
+}

--- a/PlanGo_frontend/src/app/itineraries/itineraries.component.html
+++ b/PlanGo_frontend/src/app/itineraries/itineraries.component.html
@@ -11,6 +11,7 @@
           <p>Creado por: {{ itinerary.creator_user }}</p>
           <p>Inicio: {{ itinerary.start_date }}</p>
           <p>Fin: {{ itinerary.end_date }}</p>
+          <p>{{ itinerary.destinations_count || 0 }}<strong>Destinos</strong></p>
         </div>
       </li>
     </ul>


### PR DESCRIPTION
This pull request introduces a new feature to display the number of destinations in itineraries across both the backend and frontend. It also includes temporary debugging print statements for testing purposes. Below is a summary of the most important changes:

### Backend Updates:
* Added a `destinations_count` field to the JSON response for itineraries in both the `get_itineraries` and `get_itineraries_by_user` endpoints. This field calculates the count of destinations associated with each itinerary (`PlanGo_backend/apps/itineraries/views.py`). [[1]](diffhunk://#diff-cadeadc0efb24d209ad88044ea3a7f75f305d5e19df567b3b3169ed09d4a5151R39-R43) [[2]](diffhunk://#diff-cadeadc0efb24d209ad88044ea3a7f75f305d5e19df567b3b3169ed09d4a5151R59-R63)
* Introduced debugging print statements (`print("PEPITO", data)` and `print("PEPITA", data)`) to log itinerary data for testing purposes in the same endpoints (`PlanGo_backend/apps/itineraries/views.py`). [[1]](diffhunk://#diff-cadeadc0efb24d209ad88044ea3a7f75f305d5e19df567b3b3169ed09d4a5151R39-R43) [[2]](diffhunk://#diff-cadeadc0efb24d209ad88044ea3a7f75f305d5e19df567b3b3169ed09d4a5151R59-R63)

### Frontend Updates:
* Updated the `Itinerary` interface to include an optional `destinations_count` field to align with the backend changes (`PlanGo_frontend/src/app/itineraries/interfaces/itinerary.interface.ts`).
* Modified the itineraries component template to display the number of destinations for each itinerary, defaulting to `0` if the value is not provided (`PlanGo_frontend/src/app/itineraries/itineraries.component.html`).