### PR TITLE
style: Update header and itineraries components to use CSS variables for colors

### DIFF
--- a/PlanGo_frontend/src/app/header/header.component.html
+++ b/PlanGo_frontend/src/app/header/header.component.html
@@ -1,4 +1,4 @@
-<header class="h-lvh w-16 bg-[#4c43ce]">
+<header class="h-lvh w-16 bg-[--primary-color]">
     <nav class=" h-lvh flex flex-col justify-between">
         <div class="flex flex-col items-center m-3">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1" stroke="white"

--- a/PlanGo_frontend/src/app/itineraries/itineraries.component.html
+++ b/PlanGo_frontend/src/app/itineraries/itineraries.component.html
@@ -31,7 +31,7 @@
           <h1 class="text-4xl font-bold text-gray-800">Itinerarios</h1>
             <hr class="flex-grow border-black border-2 mt-4">
         </div>
-        <button class="add-itinerary h-12 bg-[#4c43ce] text-white px-4 py-2 rounded-full hover:bg-[#6c61ff] transition duration-300">
+        <button class="add-itinerary h-12 bg-[--primary-color] text-white px-4 py-2 rounded-full hover:bg-[--secondary-color] transition duration-300">
           Añadir itinerario
         </button>
       </div>
@@ -41,7 +41,7 @@
       <div *ngIf="itineraries.length > 0" class=" mt-6">
         <ul>
           <li *ngFor="let itinerary of itineraries" class="my-3">
-            <div class="flex flex-row items-center justify-between w-auto h-20 p-6 rounded-3xl bg-[#4c43ce] hover:bg-[#6c61ff] transition duration-300" (click)="goToDestinations(itinerary.itinerary_id)" style="cursor:pointer;">
+            <div class="flex flex-row items-center justify-between w-auto h-20 p-6 rounded-3xl bg-[--primary-color] hover:bg-[--secondary-color] transition duration-300" (click)="goToDestinations(itinerary.itinerary_id)" style="cursor:pointer;">
                 <h3 class="text-lg text text-white w-[30%]">{{ itinerary.itinerary_name }}</h3>
                 <time class="text-lg text-white w-[40%] text-center" [attr.datetime]="itinerary.start_date">
                 {{ itinerary.start_date | date:'dd-MMMM-yyyy' }} - {{ itinerary.end_date | date:'dd-MMMM-yyyy' }}


### PR DESCRIPTION
This pull request updates the color scheme in the frontend of the PlanGo application to use CSS custom properties (`--primary-color` and `--secondary-color`) instead of hardcoded hex values. This change improves maintainability and consistency across the application.

### Theme Updates:

* [`PlanGo_frontend/src/app/header/header.component.html`](diffhunk://#diff-20f9ef905294b346a0a81813e315432a2d6010cc71e4e53f81e55809661dca47L1-R1): Replaced the hardcoded background color `#4c43ce` with the CSS custom property `--primary-color` in the `<header>` element.

* `PlanGo_frontend/src/app/itineraries/itineraries.component.html`: 
  - Updated the "Add Itinerary" button's background color from `#4c43ce` to `--primary-color` and its hover state from `#6c61ff` to `--secondary-color`.
  - Changed the itinerary list item's background color from `#4c43ce` to `--primary-color` and its hover state from `#6c61ff` to `--secondary-color`.