### PR TITLE
Dev 66 create itineraries

### DIFF
--- a/PlanGo_backend/config/settings.py
+++ b/PlanGo_backend/config/settings.py
@@ -61,6 +61,7 @@ INSTALLED_APPS += [
 AUTH_USER_MODEL = 'users.User'
 
 MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -69,9 +70,8 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'core.middleware.firebase_authentication.FirebaseAuthenticationMiddleware',
+    'django.middleware.common.CommonMiddleware',
 ]
-
-MIDDLEWARE.insert(0, 'corsheaders.middleware.CorsMiddleware')
 
 CORS_ALLOWED_ORIGINS = [
     'http://localhost:4200'

--- a/PlanGo_frontend/src/app/itineraries/itineraries.component.html
+++ b/PlanGo_frontend/src/app/itineraries/itineraries.component.html
@@ -60,12 +60,7 @@
     </section>
 
     <section class="map w-[35%]">
-      <gmp-map 
-      [center]="center" 
-      [zoom]="zoom" 
-      [options]="mapOptions" 
-      style="height: 100%; width: 100%;">
-      </gmp-map>
+      <app-map></app-map>
     </section>
   </div>
 </div>

--- a/PlanGo_frontend/src/app/itineraries/itineraries.component.ts
+++ b/PlanGo_frontend/src/app/itineraries/itineraries.component.ts
@@ -6,7 +6,6 @@ import { HeaderComponent } from '../header/header.component';
 import { GoogleMapsModule } from '@angular/google-maps';
 import { Router } from '@angular/router';
 
-
 @Component({
   standalone: true,
   selector: 'app-itineraries',
@@ -24,7 +23,7 @@ export class ItinerariesComponent implements OnInit {
     mapId: 'DEMO_MAP_ID',
     disableDefaultUI: true,
   };
-  map!: google.maps.Map;
+  
 
 constructor(private itinerariesService: ItinerariesService, private router: Router) {}
 

--- a/PlanGo_frontend/src/app/itineraries/itineraries.component.ts
+++ b/PlanGo_frontend/src/app/itineraries/itineraries.component.ts
@@ -5,25 +5,19 @@ import { CommonModule } from '@angular/common';
 import { HeaderComponent } from '../header/header.component';
 import { GoogleMapsModule } from '@angular/google-maps';
 import { Router } from '@angular/router';
+import { MapComponent } from '../map/map.component';
 
 @Component({
   standalone: true,
   selector: 'app-itineraries',
   templateUrl: './itineraries.component.html',
   styleUrls: ['./itineraries.component.css'],
-  imports: [CommonModule, HeaderComponent, GoogleMapsModule], 
+  imports: [CommonModule, HeaderComponent, GoogleMapsModule, MapComponent], 
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
 export class ItinerariesComponent implements OnInit {
   itineraries: Itinerary[] = [];
-  errorMessage: string = '';
-  center = { lat: 39.720007, lng: 2.910419 };
-  zoom = 13;
-  mapOptions: google.maps.MapOptions = {
-    mapId: 'DEMO_MAP_ID',
-    disableDefaultUI: true,
-  };
-  
+  errorMessage: string = '';  
 
 constructor(private itinerariesService: ItinerariesService, private router: Router) {}
 

--- a/PlanGo_frontend/src/app/map/map.component.html
+++ b/PlanGo_frontend/src/app/map/map.component.html
@@ -1,8 +1,6 @@
-<section class="map w-[35%]">
-    <gmp-map 
-      [center]="mapConfig.center" 
-      [zoom]="mapConfig.zoom" 
-      [options]="mapConfig.mapOptions"
-      style="height: 100%; width: 100%;">
-    </gmp-map>
-</section>
+<gmp-map 
+  [center]="center" 
+  [zoom]="zoom" 
+  [options]="mapOptions"
+  style="height: 100%; width: 100%;">
+</gmp-map>

--- a/PlanGo_frontend/src/app/map/map.component.html
+++ b/PlanGo_frontend/src/app/map/map.component.html
@@ -1,0 +1,8 @@
+<section class="map w-[35%]">
+    <gmp-map 
+      [center]="mapConfig.center" 
+      [zoom]="mapConfig.zoom" 
+      [options]="mapConfig.mapOptions"
+      style="height: 100%; width: 100%;">
+    </gmp-map>
+</section>

--- a/PlanGo_frontend/src/app/map/map.component.spec.ts
+++ b/PlanGo_frontend/src/app/map/map.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MapComponent } from './map.component';
+
+describe('MapComponent', () => {
+  let component: MapComponent;
+  let fixture: ComponentFixture<MapComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MapComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(MapComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/PlanGo_frontend/src/app/map/map.component.ts
+++ b/PlanGo_frontend/src/app/map/map.component.ts
@@ -1,0 +1,16 @@
+import { Component, Input, OnInit, ViewChild } from '@angular/core';
+import { GoogleMapsModule, GoogleMap } from '@angular/google-maps';
+
+@Component({
+  standalone: true,
+  selector: 'app-map',
+  templateUrl: './map.component.html',
+  styleUrls: ['./map.component.css'],
+  imports: [GoogleMapsModule],
+})
+
+export class MapComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/PlanGo_frontend/src/app/map/map.component.ts
+++ b/PlanGo_frontend/src/app/map/map.component.ts
@@ -1,5 +1,5 @@
-import { Component, Input, OnInit, ViewChild } from '@angular/core';
-import { GoogleMapsModule, GoogleMap } from '@angular/google-maps';
+import { Component, Input, OnInit, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { GoogleMapsModule } from '@angular/google-maps';
 
 @Component({
   standalone: true,
@@ -7,9 +7,16 @@ import { GoogleMapsModule, GoogleMap } from '@angular/google-maps';
   templateUrl: './map.component.html',
   styleUrls: ['./map.component.css'],
   imports: [GoogleMapsModule],
+  schemas: [CUSTOM_ELEMENTS_SCHEMA], // Allow custom elements like <gmp-map>
 })
-
 export class MapComponent implements OnInit {
+  @Input() center = { lat: 39.720007, lng: 2.910419 }; // Default center
+  @Input() zoom = 13; // Default zoom level
+  @Input() mapOptions: google.maps.MapOptions = {
+    mapId: 'DEMO_MAP_ID',
+    disableDefaultUI: true,
+  };
+
   constructor() {}
 
   ngOnInit(): void {}


### PR DESCRIPTION
This pull request introduces middleware adjustments in the backend and modularizes the map functionality in the frontend by creating a reusable `MapComponent`. The most important changes include adding the CORS middleware to the Django settings, replacing inline map logic in the itineraries component with the new `MapComponent`, and implementing unit tests for the `MapComponent`.

### Backend changes:

* Added `corsheaders.middleware.CorsMiddleware` to the `MIDDLEWARE` list in `PlanGo_backend/config/settings.py` for handling Cross-Origin Resource Sharing (CORS) requests. The redundant manual insertion of this middleware was removed. (`[[1]](diffhunk://#diff-704ee5ffc1b23df248e96457997b83ccc312d8ca132e01aad237adb2703edb03R64)`, `[[2]](diffhunk://#diff-704ee5ffc1b23df248e96457997b83ccc312d8ca132e01aad237adb2703edb03R73-L75)`)

### Frontend changes:

**Map functionality modularization:**

* Replaced the inline `<gmp-map>` logic in `PlanGo_frontend/src/app/itineraries/itineraries.component.html` with the newly created `<app-map>` component, simplifying the itineraries component. (`[PlanGo_frontend/src/app/itineraries/itineraries.component.htmlL63-R63](diffhunk://#diff-14d135f025c50d81479da196fc7499887f7f892dc5d7d1cda7d7e030336a8110L63-R63)`)
* Created a reusable `MapComponent` in `PlanGo_frontend/src/app/map/map.component.ts` to encapsulate map-related logic, including properties for `center`, `zoom`, and `mapOptions`. (`[PlanGo_frontend/src/app/map/map.component.tsR1-R23](diffhunk://#diff-c70fb41de8d322a2cf4aa898fb0dfa72e7dec3c5779cd1d1969b67d7d9ade6bbR1-R23)`)
* Added the corresponding HTML template for `MapComponent` in `PlanGo_frontend/src/app/map/map.component.html` to render the Google Maps element. (`[PlanGo_frontend/src/app/map/map.component.htmlR1-R6](diffhunk://#diff-b1007e8dc44028ba8393b0df19d8109dfb96b65cb963c177059e766c3fb6e71aR1-R6)`)

**Testing:**

* Implemented unit tests for the `MapComponent` in `PlanGo_frontend/src/app/map/map.component.spec.ts` to ensure proper initialization and functionality. (`[PlanGo_frontend/src/app/map/map.component.spec.tsR1-R23](diffhunk://#diff-b17b66f5a6af649d7f70ad1921ee1b631accdca7db748cc4173459848debcbc4R1-R23)`)