### PR TITLE
feat: Integrate ng-select for country selection in itinerary form and…

### DIFF
--- a/PlanGo_frontend/package-lock.json
+++ b/PlanGo_frontend/package-lock.json
@@ -20,6 +20,7 @@
         "@angular/platform-server": "^17.3.0",
         "@angular/router": "^17.3.0",
         "@angular/ssr": "^17.3.16",
+        "@ng-select/ng-select": "^14.7.0",
         "express": "^4.18.2",
         "firebase": "^11.6.0",
         "jwt-decode": "^4.0.0",
@@ -4472,6 +4473,24 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/@ng-select/ng-select": {
+      "version": "14.7.0",
+      "resolved": "https://registry.npmjs.org/@ng-select/ng-select/-/ng-select-14.7.0.tgz",
+      "integrity": "sha512-KVSrMt5JoMzf1U9RyyS1WfWXxWyy62rqSeu0cV+OKA5SV1q8CVxgScqXwzUaoCRdBVvRcpRNEFpjWdbsprrUJw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8"
+      },
+      "peerDependencies": {
+        "@angular/common": "^19.0.0",
+        "@angular/core": "^19.0.0",
+        "@angular/forms": "^19.0.0"
       }
     },
     "node_modules/@ngtools/webpack": {

--- a/PlanGo_frontend/package.json
+++ b/PlanGo_frontend/package.json
@@ -23,6 +23,7 @@
     "@angular/platform-server": "^17.3.0",
     "@angular/router": "^17.3.0",
     "@angular/ssr": "^17.3.16",
+    "@ng-select/ng-select": "^14.7.0",
     "express": "^4.18.2",
     "firebase": "^11.6.0",
     "jwt-decode": "^4.0.0",

--- a/PlanGo_frontend/src/app/itineraries/itineraries.component.css
+++ b/PlanGo_frontend/src/app/itineraries/itineraries.component.css
@@ -1,0 +1,64 @@
+::ng-deep ng-dropdown-panel {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    width: 100%;
+    margin-top: 0.5rem;
+    background-color: #f9fafb;
+    border: 1px solid #d1d5db;
+    border-radius: 0.5rem;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    z-index: 1050;
+}
+
+::ng-deep ng-dropdown-panel .ng-option {
+    padding: 0.5rem 1rem;
+    color: #374151;
+    cursor: pointer;
+}
+
+::ng-deep ng-dropdown-panel .ng-option:hover {
+    background-color: #e5e7eb;
+}
+
+::ng-deep .ng-select .ng-value {
+    background-color: var(--primary-color);
+    color: white;
+    border-radius: 3rem;
+    padding: 0.3rem;
+    margin-right: 0.2rem;
+    font-size: 0.9rem;
+}
+
+::ng-deep .ng-select .ng-value .ng-value-icon {
+    color: #ffffff;
+    margin-right: 0.5rem;
+}
+
+::ng-deep .ng-select .ng-value .ng-value-icon:hover {
+    color: #ef4444;
+}
+
+::ng-deep .ng-select {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    padding: 0.5rem 1rem;
+    min-height: 3rem;
+    width: 100%;
+    box-sizing: border-box;
+}
+
+::ng-deep .ng-select .ng-value-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.3rem;
+    align-items: center;
+}
+
+::ng-deep .ng-select .ng-input {
+    margin: 0;
+    padding: 0;
+    flex: 1;
+    align-self: center;
+}

--- a/PlanGo_frontend/src/app/itineraries/itineraries.component.html
+++ b/PlanGo_frontend/src/app/itineraries/itineraries.component.html
@@ -59,7 +59,7 @@
     </div>
     <form [formGroup]="itineraryForm" (ngSubmit)="onSubmit()" class="mt-6">
       <div class="mb-4 h-20">
-        <label for="itineraryName" class="block text-gray-700">Itinerary name</label>
+        <label for="itineraryName" class="block text-gray-700">Nombre del itinerario</label>
         <input id="itineraryName" formControlName="itineraryName" type="text" class="w-full h-12 border p-2 rounded-full" placeholder="Enter itinerary name" required>
         <p *ngIf="itineraryForm.get('itineraryName')?.invalid && itineraryForm.get('itineraryName')?.touched" class="text-red-500 text-sm">
           Es obligatorio el nombre del itinerario.
@@ -67,16 +67,19 @@
       </div>
 
       <div class="mb-4 h-20">
-        <label for="countries" class="block text-gray-700">Countries to visit</label>
+        <label for="countries" class="block text-gray-700">Países a visitar</label>
         <div class="relative">
-          <select id="countries" (change)="onCountriesChange()" formControlName="countries" class="w-full h-12 border p-2 rounded-full relative z-10">
-            <option *ngFor="let country of countries" [value]="country.code">
-              {{ country.name }}
-            </option>
-          </select>
+          <ng-select 
+            [items]="countries" 
+            bindLabel="name" 
+            bindValue="code" 
+            formControlName="countries" 
+            [multiple]="true" 
+            class="w-full h-12 border rounded-full bg-white text-black border-gray-800">
+          </ng-select>
         </div>
         <p *ngIf="itineraryForm.get('countries')?.invalid && itineraryForm.get('countries')?.touched" class="text-red-500 text-sm">
-          Please select at least one country.
+          Por favor, selecciona al menos un país..
         </p>
       </div>
 
@@ -102,18 +105,3 @@
     </form>
   </div>
 </div>
-
-<script>
-  fetch('https://restcountries.com/v3.1/all')
-    .then(response => response.json())
-    .then(data => {
-      const select = document.getElementById('itineraryNameDropdown');
-      data.sort((a, b) => a.name.common.localeCompare(b.name.common));
-      data.forEach(country => {
-        const option = document.createElement('option');
-        option.value = country.cca2;
-        option.text = country.name.common;
-        select.appendChild(option);
-      });
-    });
-</script>

--- a/PlanGo_frontend/src/app/itineraries/itineraries.component.ts
+++ b/PlanGo_frontend/src/app/itineraries/itineraries.component.ts
@@ -7,13 +7,14 @@ import { HeaderComponent } from '../header/header.component';
 import { GoogleMapsModule } from '@angular/google-maps';
 import { Router } from '@angular/router';
 import { MapComponent } from '../map/map.component';
+import { NgSelectModule } from '@ng-select/ng-select';
 
 @Component({
   standalone: true,
   selector: 'app-itineraries',
   templateUrl: './itineraries.component.html',
   styleUrls: ['./itineraries.component.css'],
-  imports: [CommonModule, HeaderComponent, GoogleMapsModule, MapComponent, ReactiveFormsModule], 
+  imports: [CommonModule, HeaderComponent, GoogleMapsModule, MapComponent, ReactiveFormsModule, NgSelectModule], 
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
 export class ItinerariesComponent implements OnInit {


### PR DESCRIPTION
This pull request introduces the `@ng-select/ng-select` library to enhance the dropdown functionality in the itineraries feature of the `PlanGo_frontend` project. It also includes styling updates, localization changes, and the removal of redundant JavaScript code for fetching country data.

### Library Integration:
* Added `@ng-select/ng-select` as a dependency in `package.json` and `package-lock.json` to provide a more user-friendly dropdown component. [[1]](diffhunk://#diff-a02c021f206ae8458712f0cddc98d6bb0edad9e1c7e95ce3db18a788876a0bf0R23) [[2]](diffhunk://#diff-145d8937546b8bf45d2331ed15428b1d9d89e3e3da1a450f76fbc440c8a75e11R26) [[3]](diffhunk://#diff-a02c021f206ae8458712f0cddc98d6bb0edad9e1c7e95ce3db18a788876a0bf0R4478-R4495)
* Imported `NgSelectModule` into `itineraries.component.ts` and included it in the `imports` array of the component.

### UI Enhancements:
* Replaced the native `<select>` element with the `ng-select` component in `itineraries.component.html` for selecting countries, enabling multi-select and improved styling.

### Styling Updates:
* Added custom CSS rules in `itineraries.component.css` to style the `ng-select` dropdown and its options for better alignment with the application's design.

### Localization:
* Updated labels and error messages in `itineraries.component.html` to Spanish for consistency with the application's language.

### Code Cleanup:
* Removed inline JavaScript for fetching and populating country data, as this functionality is now handled by the `ng-select` component.… update styles