### PR TITLE
feat: Adjust destination card layout for better spacing and alignment…

### DIFF
--- a/PlanGo_frontend/src/app/destinations/destinations.component.html
+++ b/PlanGo_frontend/src/app/destinations/destinations.component.html
@@ -95,7 +95,7 @@
           *ngFor="let destination of destinations"
           class="flex flex-row mt-4 items-center justify-between w-auto h-20 p-6 rounded-3xl bg-[--primary-color] hover:bg-[--secondary-color] transition duration-300"
           style="cursor:pointer;">
-          <h3 class="text-lg text-white">{{ destination.city_name }}</h3>
+          <h3 class="text-lg text-white w-[93px]">{{ destination.city_name }}</h3>
           <app-day-counter 
             class="-translate-x-4" 
             [idDestino]="destination.destination_id" 
@@ -106,7 +106,7 @@
           </app-day-counter>
           <h1 class="text-xl w-24 flex justify-center items-center text-center text-white -translate-x-6">{{ summary[destination.destination_id]?.accommodations_count }}</h1>
           <h1 class="text-xl w-24 flex justify-center items-center text-center text-white -translate-x-4">{{ summary[destination.destination_id]?.restaurants_count }}</h1>
-          <h1 class="text-xl w-24 flex justify-center items-center text-center text-white -translate-x-4">{{ summary[destination.destination_id]?.activities_count }}</h1>
+          <h1 class="text-xl w-24 flex justify-center items-center text-center text-white -translate-x-2">{{ summary[destination.destination_id]?.activities_count }}</h1>
           <div class="rounded-full w-20 h-12 bg-white text-center flex flex-row justify-center items-center">{{ summary[destination.destination_id]?.total_expenses | currency:'EUR' }}</div>
         </div>
       </div>

--- a/PlanGo_frontend/src/app/itineraries/itineraries.component.ts
+++ b/PlanGo_frontend/src/app/itineraries/itineraries.component.ts
@@ -107,7 +107,7 @@ export class ItinerariesComponent implements OnInit {
       this.countries = data
         .map((country: any) => ({
           code: country.cca2,
-          name: country.name.common,
+          name: country.translations?.spa?.common || country.name.common, // Nombre en español o común si no está disponible
         }))
         .sort((a: any, b: any) => a.name.localeCompare(b.name));
     } catch (error) {


### PR DESCRIPTION
This pull request includes minor updates to improve the UI layout and enhance localization in the `PlanGo_frontend` project. The changes adjust styling for better alignment and readability, and modify the logic to display country names in Spanish when available.

### UI Layout Adjustments:

* [`PlanGo_frontend/src/app/destinations/destinations.component.html`](diffhunk://#diff-b4ca1098917bdc868492f1bb1a0282eb42342ef8f1ae7a4bb05bf453368014f5L98-R98): Added a fixed width (`w-[93px]`) to the city name element to ensure consistent alignment across destinations.
* [`PlanGo_frontend/src/app/destinations/destinations.component.html`](diffhunk://#diff-b4ca1098917bdc868492f1bb1a0282eb42342ef8f1ae7a4bb05bf453368014f5L109-R109): Adjusted the horizontal translation (`-translate-x-2`) for the activities count element to improve alignment with other summary elements.

### Localization Enhancement:

* [`PlanGo_frontend/src/app/itineraries/itineraries.component.ts`](diffhunk://#diff-b5866671dc4086fa567b9c6751d0af6f3ec68f76595c96c9fdbf523afe7a115eL110-R110): Updated the logic to display country names in Spanish (`translations?.spa?.common`) when available, falling back to the common name if Spanish translations are not provided.…; update country name retrieval to prefer Spanish translations