### PR TITLE
feat: Enhance expense details layout with improved structure and adde…

### DIFF
--- a/PlanGo_frontend/src/app/expenses/expenses.component.html
+++ b/PlanGo_frontend/src/app/expenses/expenses.component.html
@@ -56,9 +56,17 @@
     <section class="p-8 border-l-2 border-gray w-[35%] h-screen overflow-y-auto">
       <div *ngIf="selectedExpense; else noExpense">
         <!-- Cluster 1 -->
-        <div class="mb-8 flex flex-row">
-          <h1 class="text-xl font-bold">Nombre: </h1> 
-          <h1 class="text-xl font-normal"> {{ selectedExpense.Gasto.itinerary_name }} - {{ selectedExpense.Gasto.city_name }}</h1>
+        <div class="mb-8 flex flex-col items-center justify-between">
+          <div class="flex flex-col">
+            <div class="flex flex-row">
+              <h1 class="text-xl font-bold">Nombre: </h1> 
+              <span class="mx-2"></span>
+              <h1 class="text-xl font-normal flex flex-row justify-between"> {{ selectedExpense.Gasto.itinerary_name }} - {{ selectedExpense.Gasto.city_name }}</h1>
+            </div>
+          </div>
+            <div class="rounded-full mt-6 bg-[--primary-color] h-12 text-center text-white font-bold flex px-4 items-center">
+            Tipo: {{ selectedExpense.Gasto.type_expense === 'Equalitarian' ? 'Equitativo' : 'Personalizado' }}
+            </div>
         </div>
         <div class="my-4 flex flex-row justify-between items-center">
           <h2 class="text-md">Costes totales:</h2>


### PR DESCRIPTION
This pull request updates the layout and styling of the `expenses.component.html` file in the PlanGo frontend to improve the user interface and provide better visual clarity for expense details.

### UI Improvements:
* Updated the layout of the expense details section to use a column-based structure (`flex flex-col`) instead of a row-based structure (`flex flex-row`). This change enhances alignment and readability.
* Added a new rounded button-like element to display the type of expense (`Equalitarian` or `Personalizado`) with improved styling (`rounded-full`, `bg-[--primary-color]`, `text-white`).…d expense type display