### PR TITLE
feat: Implement formatCountries method to enhance country display in itinerary

### DIFF
--- a/PlanGo_frontend/src/app/destinations/destinations.component.html
+++ b/PlanGo_frontend/src/app/destinations/destinations.component.html
@@ -36,7 +36,7 @@
           </div>
         </div>
         <div class="h-24 w-full flex justify-center items-center">
-          <h1 class="text-4xl font-bold">{{ selectedItinerary?.countries }}</h1>
+          <h1 class="text-4xl font-bold">{{ formatCountries() }}</h1>
         </div>
       </div>
       

--- a/PlanGo_frontend/src/app/destinations/destinations.component.ts
+++ b/PlanGo_frontend/src/app/destinations/destinations.component.ts
@@ -128,6 +128,24 @@ constructor(
     }
   }
 
+  formatCountries(): string {
+    if (!this.selectedItinerary?.countries) {
+      return '';
+    }
+  
+    const countriesArray = this.selectedItinerary.countries.split(',');
+    const length = countriesArray.length;
+  
+    if (length === 2) {
+      return countriesArray.join(' y ');
+    } else if (length > 2) {
+      const lastCountry = countriesArray.pop();
+      return `${countriesArray.join(', ')} y ${lastCountry}`;
+    }
+  
+    return this.selectedItinerary.countries; // Return as is if there's only one country
+  }
+
   goPlaces(){
     this.router.navigate(['/search/places']);
   }


### PR DESCRIPTION
This pull request improves the display of selected itinerary countries in the `destinations` component by introducing a new method to format the country list. The changes enhance readability when multiple countries are displayed.

### Changes to improve country list formatting:

* [`PlanGo_frontend/src/app/destinations/destinations.component.html`](diffhunk://#diff-b4ca1098917bdc868492f1bb1a0282eb42342ef8f1ae7a4bb05bf453368014f5L39-R39): Updated the binding for displaying countries to use the new `formatCountries()` method instead of directly referencing `selectedItinerary?.countries`.

* [`PlanGo_frontend/src/app/destinations/destinations.component.ts`](diffhunk://#diff-60b5fe0d820452b86c04ae345e270daf3d259d5d3557d2b368b9ef7efb1bc630R131-R148): Added the `formatCountries()` method to handle formatting of country lists. It formats the list with "y" as a separator for the last two countries, improving readability for two or more countries.