### PR TITLE
feat: Update itinerary creation to format start and end dates

### DIFF
--- a/PlanGo_frontend/src/app/itineraries/itineraries.component.ts
+++ b/PlanGo_frontend/src/app/itineraries/itineraries.component.ts
@@ -80,11 +80,12 @@ export class ItinerariesComponent implements OnInit {
               let countries = this.itineraryForm.get('countries')?.value.map((country: string) => country);
 
               let newItinerary: Itinerary = {
+                
                 itinerary_name: this.itineraryForm.get('itineraryName')?.value,
                 creator_user: userId,
                 creation_date: new Date().toISOString().split('T')[0],
-                start_date: this.itineraryForm.get('startDate')?.value,
-                end_date: this.itineraryForm.get('endDate')?.value,
+                start_date: (this.itineraryForm.get('startDate')?.value).toISOString().split('T')[0],
+                end_date: (this.itineraryForm.get('endDate')?.value).toISOString().split('T')[0],
                 countries: countries, // Enviar como array
               };
               this.toast.showSuccessToast('Se han añadido el itinerario', false);
@@ -122,7 +123,7 @@ export class ItinerariesComponent implements OnInit {
       }
     });
   }
-
+  
   async getCountries(): Promise<void> {
     try {
       let response = await fetch(globals.countriesRest);
@@ -133,11 +134,11 @@ export class ItinerariesComponent implements OnInit {
           name: country.translations?.spa?.common || country.name.common, 
         }))
         .sort((a: any, b: any) => a.name.localeCompare(b.name));
-    } catch (error) {
-      console.error('Error al obtener los países:', error);
+      } catch (error) {
+        console.error('Error al obtener los países:', error);
+      }
     }
-  }
-
+    
   onCountriesChange(): void {
     let selectedCountries = this.itineraryForm.get('destinations')?.value || [];
     console.log('Países seleccionados:', selectedCountries);


### PR DESCRIPTION
This pull request includes a change to the `ItinerariesComponent` class in the `PlanGo_frontend` project. The update ensures that the `start_date` and `end_date` fields are formatted as ISO strings before being assigned to the `newItinerary` object.

Formatting improvements:

* [`PlanGo_frontend/src/app/itineraries/itineraries.component.ts`](diffhunk://#diff-b5866671dc4086fa567b9c6751d0af6f3ec68f76595c96c9fdbf523afe7a115eR83-R88): Modified the `start_date` and `end_date` fields to use `.toISOString().split('T')[0]` for consistent ISO date formatting before assigning them to the `newItinerary` object.