### PR TITLE
feat: Refactor countries handling to use allCountries and improve tra…

### DIFF
--- a/PlanGo_frontend/src/app/destinations/destinations.component.ts
+++ b/PlanGo_frontend/src/app/destinations/destinations.component.ts
@@ -160,7 +160,7 @@ constructor(
       this.allCountries = data
         .map((country: any) => ({
           code: country.cca2,
-          name: country.name.common,
+          name: country.translations?.spa?.common || country.name.common,
         }))
         .sort((a: any, b: any) => a.name.localeCompare(b.name));
     } catch (error) {

--- a/PlanGo_frontend/src/app/itineraries/itineraries.component.html
+++ b/PlanGo_frontend/src/app/itineraries/itineraries.component.html
@@ -73,7 +73,7 @@
         <label for="countries" class="block text-gray-700">Países a visitar</label>
         <div class="relative">
           <ng-select 
-            [items]="countries" 
+            [items]="allCountries" 
             bindLabel="name" 
             bindValue="name" 
             formControlName="countries" 

--- a/PlanGo_frontend/src/app/itineraries/itineraries.component.ts
+++ b/PlanGo_frontend/src/app/itineraries/itineraries.component.ts
@@ -37,7 +37,7 @@ export class ItinerariesComponent implements OnInit {
   errorMessage: string = '';
   showForm: boolean = false;
   itineraryForm: FormGroup;
-  countries: { code: string; name: string }[] = [];
+  allCountries: { code: string; name: string }[] = [];
   currentDate: Date = new Date();
   ValidatorMessages = ValidatorMessages;
   formSubmitted = false;
@@ -128,7 +128,7 @@ export class ItinerariesComponent implements OnInit {
     try {
       let response = await fetch(globals.countriesRest);
       let data = await response.json();
-      this.countries = data
+      this.allCountries = data
         .map((country: any) => ({
           code: country.cca2,
           name: country.translations?.spa?.common || country.name.common, 
@@ -143,25 +143,6 @@ export class ItinerariesComponent implements OnInit {
     let selectedCountries = this.itineraryForm.get('destinations')?.value || [];
     console.log('Países seleccionados:', selectedCountries);
   }
-  /* onMapReady(map: google.maps.Map): void {
-    this.map = map;
-  
-    this.map.addListener('dblclick', async (event: google.maps.MapMouseEvent) => {
-      if (event.latLng) await this.addAdvancedMarker(event.latLng);
-    });
-  } */
-
-  /* async addAdvancedMarker(position: google.maps.LatLng | google.maps.LatLngLiteral): Promise<void> {
-    let { AdvancedMarkerElement } = await google.maps.importLibrary(
-      'marker'
-    ) as google.maps.MarkerLibrary;
-  
-    let marker = new AdvancedMarkerElement({
-      map: this.map,
-      position: position,
-      title: 'Nuevo marcador',
-    });
-  } */
 
   goToDestinations(itineraryId: number | undefined): void {
     this.router.navigate(['/destinations', itineraryId]);


### PR DESCRIPTION
This pull request updates the handling of country data in the `PlanGo_frontend` project, improving consistency and localization by leveraging Spanish translations where available. It also removes unused code related to map markers in the `ItinerariesComponent`. The most important changes are grouped below:

### Country Data Handling Improvements:
* [`PlanGo_frontend/src/app/destinations/destinations.component.ts`](diffhunk://#diff-60b5fe0d820452b86c04ae345e270daf3d259d5d3557d2b368b9ef7efb1bc630L163-R163): Updated the `allCountries` mapping logic to prioritize Spanish translations (`country.translations?.spa?.common`) for country names, falling back to the common name if no translation is available.
* [`PlanGo_frontend/src/app/itineraries/itineraries.component.ts`](diffhunk://#diff-b5866671dc4086fa567b9c6751d0af6f3ec68f76595c96c9fdbf523afe7a115eL40-R40): Replaced the `countries` property with `allCountries` to unify the handling of country data and ensure Spanish translations are used when available. [[1]](diffhunk://#diff-b5866671dc4086fa567b9c6751d0af6f3ec68f76595c96c9fdbf523afe7a115eL40-R40) [[2]](diffhunk://#diff-b5866671dc4086fa567b9c6751d0af6f3ec68f76595c96c9fdbf523afe7a115eL131-R131)
* [`PlanGo_frontend/src/app/itineraries/itineraries.component.html`](diffhunk://#diff-14d135f025c50d81479da196fc7499887f7f892dc5d7d1cda7d7e030336a8110L76-R76): Updated the `ng-select` component to use `allCountries` instead of `countries` for displaying selectable countries.

### Code Cleanup:
* [`PlanGo_frontend/src/app/itineraries/itineraries.component.ts`](diffhunk://#diff-b5866671dc4086fa567b9c6751d0af6f3ec68f76595c96c9fdbf523afe7a115eL146-L164): Removed unused and commented-out code related to map markers (`onMapReady` and `addAdvancedMarker` methods) to simplify the file and improve maintainability.