### PR TITLE
Update: Change api lenguage

### DIFF
--- a/PlanGo_backend/apps/itineraries/views.py
+++ b/PlanGo_backend/apps/itineraries/views.py
@@ -243,11 +243,9 @@ def geocodenames_autocomplete(request):
     # Endpoint actualizado para Places API (New)
     url = (
         f'http://api.geonames.org/searchJSON'
-        f'?name_startsWith={input_text}&country={country_code}&featureClass=P&minPopulation=5000&maxRows=1000&username={api_key}'
+        f'?name_startsWith={input_text}&country={country_code}&featureClass=P&minPopulation=5000&maxRows=1000&username={api_key}&lang=es'
     )
-    print("URL! ", url)
     response = requests.get(url)
-    print("RESPONSEEE", response)
     if response.status_code != 200:
         return JsonResponse({'error': 'Failed to fetch data from Google Places API'}, status=response.status_code)
 


### PR DESCRIPTION
This pull request updates the `geocodenames_autocomplete` function in `PlanGo_backend/apps/itineraries/views.py` to include language support in the Geonames API request and removes unnecessary debug print statements.

Changes to API request:

* Added a `lang=es` parameter to the Geonames API URL to specify Spanish language support.

Code cleanup:

* Removed debug print statements for the URL and response to streamline the code.