### PR TITLE
fix: Update city name property to use 'toponymName' for destination p…

### DIFF
--- a/PlanGo_frontend/src/app/destinations/destinations.component.ts
+++ b/PlanGo_frontend/src/app/destinations/destinations.component.ts
@@ -267,7 +267,7 @@ constructor(
     let payload: Omit<Destination, 'destination_id'> = {
       itinerary: this.selectedItineraryId,
       country: country,
-      city_name: city.adminName1,
+      city_name: city.toponymName,
       start_date: this.itineraryStartDate as any,
       end_date: this.itineraryEndDate as any,
       latitude: Number(city.lat),


### PR DESCRIPTION
This pull request includes a minor change to the `constructor` in `PlanGo_frontend/src/app/destinations/destinations.component.ts`. The change updates the source of the `city_name` property to use `city.toponymName` instead of `city.adminName1`.…ayload