### PR TITLE
fix: Refine included types in Google Places search for nearby locations

### DIFF
--- a/PlanGo_backend/apps/places/views.py
+++ b/PlanGo_backend/apps/places/views.py
@@ -162,12 +162,12 @@ def google_places_search_nearby(request):
             ]
         case "comer y beber":
             included_types = [
-                "restaurant", "bar", "cafe", "bakery", "pub", "fast_food_restaurant", "buffet_restaurant", "food"
+                "restaurant", "bar", "cafe", "bakery", "pub", "fast_food_restaurant", "buffet_restaurant"
             ]
         case "cosas que hacer":
             included_types = [
                 "tourist_attraction", "museum", "art_gallery", "zoo", "aquarium", "park", "amusement_park", "night_club", 
-                "point_of_interest", "church", "mosque", "place_of_worship"
+                 "church", "mosque"
             ]
         case _:
             included_types = []


### PR DESCRIPTION
This pull request makes adjustments to the `google_places_search_nearby` function in `PlanGo_backend/apps/places/views.py` to refine the list of place types included for specific categories. The changes remove certain types that may not be relevant or necessary.

Refinements to category type lists:

* In the "comer y beber" category, the `food` type has been removed from the `included_types` list, narrowing the focus to specific venue types like restaurants, bars, and cafes.
* In the "cosas que hacer" category, the `point_of_interest` and `place_of_worship` types have been removed, leaving a more specific selection of places such as museums, parks, and religious establishments.