### PR TITLE
feat: Add Montserrat and Lato fonts to styles and configure Tailwind CSS font family

### DIFF
--- a/PlanGo_frontend/src/styles.css
+++ b/PlanGo_frontend/src/styles.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css?family=Montserrat:400,700&display=swap');
+@import url('https://fonts.googleapis.com/css?family=Lato:400,700&display=swap');
 /* Ensure Tailwind CSS directives are correctly included */
 @tailwind base;
 @tailwind components;
@@ -6,4 +8,12 @@
 :root {
     --primary-color: #4c43ce;
     --secondary-color: #6c61ff;
+}
+
+h1, h3 {
+  font-family: 'Lato', ui-sans-serif, system-ui, sans-serif;
+}
+
+body {
+  font-family: 'Montserrat', ui-sans-serif, system-ui, sans-serif;
 }

--- a/PlanGo_frontend/tailwind.config.js
+++ b/PlanGo_frontend/tailwind.config.js
@@ -4,7 +4,11 @@ export default {
     "./src/**/*.{html,ts}"
   ],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        sans: ['Montserrat', 'Lato', 'system-ui', 'sans-serif'],
+      }
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
This pull request introduces font styling improvements to the `PlanGo_frontend` project by integrating new font families and updating the Tailwind CSS configuration to support these changes.

### Font Styling Enhancements:

* [`PlanGo_frontend/src/styles.css`](diffhunk://#diff-fe1ca1b570f0b4069d2083c775197cb064401ab0f99a0c9189d290c43ff435a2R1-R2): Imported `Montserrat` and `Lato` fonts from Google Fonts to enhance typography options. Added custom font-family rules for `h1`, `h3`, and `body` elements to use these fonts. [[1]](diffhunk://#diff-fe1ca1b570f0b4069d2083c775197cb064401ab0f99a0c9189d290c43ff435a2R1-R2) [[2]](diffhunk://#diff-fe1ca1b570f0b4069d2083c775197cb064401ab0f99a0c9189d290c43ff435a2R12-R19)

* [`PlanGo_frontend/tailwind.config.js`](diffhunk://#diff-2705a5aaa568124905f41a127d8fea78c2545b6828f1a23b47da032d76a6b6efL7-R11): Extended the Tailwind CSS theme configuration to include `Montserrat` and `Lato` fonts in the `fontFamily.sans` property, ensuring consistent use of these fonts throughout the project.