### PR TITLE
feat: Set zoom level for map component in itineraries

### DIFF
--- a/PlanGo_frontend/src/app/itineraries/itineraries.component.html
+++ b/PlanGo_frontend/src/app/itineraries/itineraries.component.html
@@ -42,7 +42,7 @@
     </section>
 
     <section class="map w-[35%]">
-      <app-map></app-map>
+      <app-map [zoom]="2"></app-map>
     </section>
   </div>
 </div>


### PR DESCRIPTION
This pull request includes a small change to the `itineraries.component.html` file. The change adds a `zoom` property to the `<app-map>` component, setting its initial zoom level to 2.