### PR TITLE
feat: Set zoom level for map component and update photo indicator color

### DIFF
--- a/PlanGo_frontend/src/app/destinations/destinations.component.html
+++ b/PlanGo_frontend/src/app/destinations/destinations.component.html
@@ -135,7 +135,7 @@
 
     <!-- Map Section -->
     <section class="map w-[35%]">
-      <app-map></app-map>
+      <app-map [zoom]="2"></app-map>
     </section>
   </div>
 </div>

--- a/PlanGo_frontend/src/app/map/map.component.html
+++ b/PlanGo_frontend/src/app/map/map.component.html
@@ -46,7 +46,7 @@
           <div class="absolute bottom-2 left-1/2 -translate-x-1/2 flex gap-1">
             <span *ngFor="let photo of activeMarker.place.photos; let i = index"
                   class="w-2 h-2 rounded-full"
-                  [ngClass]="i === activePhotoIndex ? 'bg-blue-600' : 'bg-gray-300'"></span>
+                  [ngClass]="i === activePhotoIndex ? 'bg-[--primary-color]' : 'bg-gray-300'"></span>
           </div>
         </ng-container>
         <ng-template #noImage>


### PR DESCRIPTION
This pull request introduces minor updates to the `PlanGo_frontend` application to improve functionality and styling consistency. The changes include adding a zoom property to the map component and using a CSS variable for dynamic styling.

### Functional Updates:
* [`PlanGo_frontend/src/app/destinations/destinations.component.html`](diffhunk://#diff-b4ca1098917bdc868492f1bb1a0282eb42342ef8f1ae7a4bb05bf453368014f5L138-R138): Added `[zoom]="2"` to the `<app-map>` component to set a default zoom level for the map.

### Styling Updates:
* [`PlanGo_frontend/src/app/map/map.component.html`](diffhunk://#diff-b1007e8dc44028ba8393b0df19d8109dfb96b65cb963c177059e766c3fb6e71aL49-R49): Updated the `bg-blue-600` class to use a CSS variable `bg-[--primary-color]` for dynamic theming of active photo indicators.