### PR TITLE
Manage destiny dates

### DIFF
--- a/PlanGo_frontend/src/app/auth/auth.service.ts
+++ b/PlanGo_frontend/src/app/auth/auth.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import {  signOut } from 'firebase/auth';
+import {  signOut, sendPasswordResetEmail } from 'firebase/auth';
 import { Auth } from '@angular/fire/auth';
 import { Router } from '@angular/router';
 
@@ -17,5 +17,9 @@ export class AuthService {
       localStorage.clear();
       this.router.navigate(['/login']);
     });
+  }
+
+  resetPassword(email: string): Promise<void> {
+    return sendPasswordResetEmail(this.auth, email);
   }
 }

--- a/PlanGo_frontend/src/app/header/header.component.html
+++ b/PlanGo_frontend/src/app/header/header.component.html
@@ -1,3 +1,4 @@
+<p-toast></p-toast>
 <header [@expandHeader]="headerState" class="h-lvh bg-[--primary-color] overflow-hidden">
     <nav class="h-lvh flex flex-col justify-between">
         <div class="flex flex-col items-start justify-center m-3">
@@ -48,7 +49,7 @@
                         <hr class="my-6">
                     </div>
                     <div class="p-2 w-full h-80 flex-grow flex flex-col justify-between">
-                        <button class="h-12 bg-white text-black rounded-full">Restablecer contraseña</button>
+                        <button (click)="onResetPassword()" class="h-12 bg-white text-black rounded-full">Restablecer contraseña</button>
                         <button (click)="authService.logout()" class="h-12 bg-white text-black rounded-full">Cerrar sesión</button>
                     </div>
                 </div>

--- a/PlanGo_frontend/src/app/header/header.component.ts
+++ b/PlanGo_frontend/src/app/header/header.component.ts
@@ -6,12 +6,15 @@ import { UserService } from '../core/services/user.service';
 import { ItinerariesService } from '../core/services/itineraries.service';
 import { getAuth, signOut } from 'firebase/auth';
 import { AuthService } from '../auth/auth.service';
+import { BaseToastService } from '../core/services/base-toast.service';
+import { ToastModule } from 'primeng/toast';
 
 @Component({
   selector: 'app-header',
   standalone: true,
   imports: [
     CommonModule,
+    ToastModule,
   ],
   templateUrl: './header.component.html',
   styleUrl: './header.component.css',
@@ -45,6 +48,7 @@ export class HeaderComponent {
     private userService: UserService,
     private itinerariesService: ItinerariesService,
     public authService: AuthService,
+    public toast: BaseToastService,
   ){}
 
   ngOnInit() {
@@ -56,8 +60,16 @@ export class HeaderComponent {
             this.userEmail = userData.email;
             this.userPhoto = userData.user_image;
           }); 
-      });
-     
+      });    
+  }
+
+  onResetPassword() {
+    let email = this.userEmail || prompt('Introduce tu email para restablecer la contraseña:');
+    if (email) {
+      this.authService.resetPassword(email)
+        .then(() => this.toast.showSuccessToast('Se ha enviado un correo para restablecer la contraseña', false))
+        .catch(err => this.toast.showErrorToast(500, 'Error al enviar el correo', false));
+    }
   }
 
   toggleHeaderWidth() {


### PR DESCRIPTION
This pull request introduces functionality for password reset and integrates a toast notification system into the frontend. The most significant changes include adding a method to handle password reset requests, updating the header component to trigger these requests, and incorporating toast notifications for user feedback.

### Password Reset Functionality:
* [`PlanGo_frontend/src/app/auth/auth.service.ts`](diffhunk://#diff-4b8f2042d5971f209be7b89f39bf93ff5b05d99c7f3c867caa677cdaa6323407L2-R2): Added the `resetPassword` method to send password reset emails using Firebase's `sendPasswordResetEmail` function. [[1]](diffhunk://#diff-4b8f2042d5971f209be7b89f39bf93ff5b05d99c7f3c867caa677cdaa6323407L2-R2) [[2]](diffhunk://#diff-4b8f2042d5971f209be7b89f39bf93ff5b05d99c7f3c867caa677cdaa6323407R21-R24)
* [`PlanGo_frontend/src/app/header/header.component.html`](diffhunk://#diff-20f9ef905294b346a0a81813e315432a2d6010cc71e4e53f81e55809661dca47L51-R52): Updated the "Restablecer contraseña" button to call the new `onResetPassword` method.
* [`PlanGo_frontend/src/app/header/header.component.ts`](diffhunk://#diff-6e4ce2d64c1186f0ee28489e4b692fe7ef5e60304956a62a899ec3c6aa1ebbd3R64-R72): Added the `onResetPassword` method to prompt the user for their email and call the `resetPassword` method.

### Toast Notification Integration:
* [`PlanGo_frontend/src/app/header/header.component.html`](diffhunk://#diff-20f9ef905294b346a0a81813e315432a2d6010cc71e4e53f81e55809661dca47R1): Added the `<p-toast>` component to enable toast notifications.
* [`PlanGo_frontend/src/app/header/header.component.ts`](diffhunk://#diff-6e4ce2d64c1186f0ee28489e4b692fe7ef5e60304956a62a899ec3c6aa1ebbd3R9-R17): Imported `ToastModule` and `BaseToastService` for toast notifications and added `toast` as a dependency in the `HeaderComponent` constructor. [[1]](diffhunk://#diff-6e4ce2d64c1186f0ee28489e4b692fe7ef5e60304956a62a899ec3c6aa1ebbd3R9-R17) [[2]](diffhunk://#diff-6e4ce2d64c1186f0ee28489e4b692fe7ef5e60304956a62a899ec3c6aa1ebbd3R51)