### PR TITLE
feat: Add SavedPlacesService for managing saved places and CSRF token handling

### DIFF
--- a/PlanGo_frontend/src/app/core/services/saved-places.service.ts
+++ b/PlanGo_frontend/src/app/core/services/saved-places.service.ts
@@ -1,0 +1,64 @@
+import { Injectable, Inject, PLATFORM_ID } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { isPlatformBrowser } from '@angular/common';
+import { map, Observable, throwError } from 'rxjs';
+import { globals } from '../globals';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SavedPlacesService {
+    private csrfToken: string = '';
+
+    constructor(
+        private httpClient: HttpClient,
+        @Inject(PLATFORM_ID) private platformId: Object
+    ) {}
+
+  getSavedPlacesByCategory(userId: number): Observable<any> {
+    let token = '';
+    let headers = this.createHeaders();
+    if (isPlatformBrowser(this.platformId)) {
+      token = localStorage.getItem(globals.keys.accessToken) || '';
+    }
+    return this.httpClient.get(`${globals.apiBaseUrl}/places/get_saved_places_by_category/${userId}/`, { headers });
+  }
+
+  private createHeaders(): HttpHeaders {
+        let token = '';
+        if (isPlatformBrowser(this.platformId)) {
+            token = localStorage.getItem(globals.keys.accessToken) || '';
+        }
+
+        return new HttpHeaders({
+            Authorization: `Bearer ${token}`,
+            'X-CSRFToken': this.csrfToken,
+            'Content-Type': 'application/json',
+        });
+    }
+
+    getCsrfTokenFromServer(): Observable<string> {
+        if (!isPlatformBrowser(this.platformId)) return throwError(() => new Error('localStorage is not available in this environment'));
+
+        const token = localStorage.getItem(globals.keys.accessToken) || '';
+        if (!token) {
+            return throwError(() => new Error('Token de usuario no disponible'));
+        }
+
+        const headers = new HttpHeaders({
+            Authorization: `Bearer ${token}`,
+        });
+
+        return this.httpClient.get<{ csrftoken: string }>(`${globals.apiBaseUrl}/itineraries/csrf-token/`, {
+            headers,
+            withCredentials: true,
+        }).pipe(
+            map((response) => response.csrftoken)
+        );
+    }
+
+    setCsrfToken(token: string): void {
+        console.log('CSRF token recibido:', token);
+        this.csrfToken = token.replace(/^"|"$/g, '');
+    }
+}


### PR DESCRIPTION
This pull request introduces a new service, `SavedPlacesService`, in the Angular frontend application to manage saved places functionality. The service includes methods for retrieving saved places by category, handling CSRF tokens, and creating HTTP headers with authentication. 

### New Service Implementation:

* [`PlanGo_frontend/src/app/core/services/saved-places.service.ts`](diffhunk://#diff-52cad42773765b22a96cd1e0b9c9701e5df0914b21ec48de0575aaf0dab9944eR1-R64): Added the `SavedPlacesService` class, which includes methods for fetching saved places by category (`getSavedPlacesByCategory`), retrieving CSRF tokens from the server (`getCsrfTokenFromServer`), setting CSRF tokens (`setCsrfToken`), and creating HTTP headers (`createHeaders`). The service uses Angular's `HttpClient` and supports browser-specific functionality via `isPlatformBrowser`.