### PR TITLE
Dev 54 destination functionalities

### DIFF
--- a/PlanGo_backend/apps/places/views.py
+++ b/PlanGo_backend/apps/places/views.py
@@ -394,15 +394,13 @@ def google_places_search_nearby(request):
     response = requests.post(url, json=payload, headers=headers)
     data = response.json()
 
-    # --- Añade isSave a cada lugar ---
     from apps.places.models.saved_place import SavedPlace
     saved_place_ids = set()
     if user_id:
         saved_place_ids = set(SavedPlace.objects.filter(user_id=user_id).values_list('place_id', flat=True))
 
     for place in data.get('places', []):
-        place_id = str(place.get('id'))
-        place['isSave'] = place_id in set(str(pid) for pid in saved_place_ids)
+        place['isSave'] = place.get('id') in saved_place_ids
     return JsonResponse(data, safe=False)
 
 

--- a/PlanGo_backend/apps/places/views.py
+++ b/PlanGo_backend/apps/places/views.py
@@ -427,6 +427,7 @@ def get_all_categories_from_destination(request):
             images_data = [img.uri for img in images]
             accommodations_data.append({
                 'accommodation': alj.name,
+                'id': alj.place_id
                 'accommodaton_type': alj.accomodation_type,
                 'address': alj.address,
                 'rating': alj.rating if alj.rating is not None else 3.0,
@@ -444,6 +445,7 @@ def get_all_categories_from_destination(request):
             images_data = [img.uri for img in images]
             restaurants_data.append({
                 'restaurant': rest.name,
+                'id': rest.place_id,
                 'restaurant_type': rest.restaurant_type,
                 'rating': rest.rating if rest.rating is not None else 3.0,
                 'address': rest.address,
@@ -461,6 +463,7 @@ def get_all_categories_from_destination(request):
             images_data = [img.uri for img in images]
             activities_data.append({
                 'activity': act.name,
+                'place_id': act.place_id,
                 'activity_type': act.activity_type,
                 'rating': act.rating if act.rating is not None else 3.0,
                 'address': act.address,

--- a/PlanGo_frontend/src/app/core/services/saved-places.service.ts
+++ b/PlanGo_frontend/src/app/core/services/saved-places.service.ts
@@ -35,7 +35,6 @@ export class SavedPlacesService {
         let csrfToken = '';
         if (isPlatformBrowser(this.platformId)) {
             token = localStorage.getItem(globals.keys.accessToken) || '';
-            // Lee la cookie csrftoken directamente
             const match = document.cookie.match(/csrftoken=([^;]+)/);
             csrfToken = match ? match[1] : '';
         }

--- a/PlanGo_frontend/src/app/map/map.component.html
+++ b/PlanGo_frontend/src/app/map/map.component.html
@@ -15,7 +15,7 @@
         </span>
         <span class="text-sm flex items-center gap-1">
           <!-- i de información -->
-          <button pTooltip="Se te va a redirigir para ver más información" tooltipPosition="top" type="button"
+          <button pTooltip="Ver más información en Google Maps" tooltipPosition="top" type="button"
             (click)="openGoogleMapsPlace()">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="gray"
               class="size-6">

--- a/PlanGo_frontend/src/app/map/map.component.ts
+++ b/PlanGo_frontend/src/app/map/map.component.ts
@@ -93,7 +93,7 @@ export class MapComponent implements OnInit {
   }
 
   openGoogleMapsPlace(): void {
-    let placeId = this.activeMarker?.place?.id;
+    let placeId = this.activeMarker?.place?.id || this.activeMarker?.place?.place_id;
     if (placeId) {
       window.open(`https://www.google.com/maps/place/?q=place_id:${placeId}`, '_blank');
     }

--- a/PlanGo_frontend/src/app/saved-places/saved-places.component.ts
+++ b/PlanGo_frontend/src/app/saved-places/saved-places.component.ts
@@ -160,7 +160,7 @@ export class SavedPlacesComponent {
         lat: Number(place.latitude),
         lng: Number(place.longitude),
         label: place.accommodation || place.restaurant || place.activity || place.displayName?.text || '',
-        place: { ...place }
+        place: { ...place },
       };
       this.markers = [marker];
       this.mapLocation = { lat: marker.lat, lng: marker.lng };

--- a/PlanGo_frontend/src/app/search-places/search-places.component.ts
+++ b/PlanGo_frontend/src/app/search-places/search-places.component.ts
@@ -300,7 +300,7 @@ export class SearchPlacesComponent {
           place_id: place.id,
           destination: this.currentDestination?.destination_id,
           name: place.displayName?.text,
-          primary_type: place.primaryType,
+          primary_type: place.primaryType ? place.primaryType : (place.types && place.types.length > 0 ? place.types[0] : ''),
           rating: place.rating,
           formattedAddress: place.formattedAddress,
           latitude: place.location?.latitude,


### PR DESCRIPTION
This pull request includes changes to improve data handling and user experience in both the backend and frontend of the PlanGo application. The most important changes involve simplifying logic for checking saved places, adding missing identifiers to various data objects, enhancing tooltip messages, and improving fallback logic for place types.

### Backend improvements:

* Simplified the logic in `google_places_search_nearby` to check if a place is saved by directly comparing `place.get('id')` with `saved_place_ids`. (`PlanGo_backend/apps/places/views.py`, [PlanGo_backend/apps/places/views.pyL397-R403](diffhunk://#diff-1fd835264a07d9c034140ed1a44e5dfdfaa4635c7a09756cfce5fdf6478b5062L397-R403))
* Added missing `place_id` fields to accommodations, restaurants, and activities in `get_all_categories_from_destination`. (`PlanGo_backend/apps/places/views.py`, [[1]](diffhunk://#diff-1fd835264a07d9c034140ed1a44e5dfdfaa4635c7a09756cfce5fdf6478b5062R430) [[2]](diffhunk://#diff-1fd835264a07d9c034140ed1a44e5dfdfaa4635c7a09756cfce5fdf6478b5062R448) [[3]](diffhunk://#diff-1fd835264a07d9c034140ed1a44e5dfdfaa4635c7a09756cfce5fdf6478b5062R466)

### Frontend improvements:

* Updated tooltip text in `map.component.html` to clarify that clicking the button redirects users to Google Maps for more information. (`PlanGo_frontend/src/app/map/map.component.html`, [PlanGo_frontend/src/app/map/map.component.htmlL18-R18](diffhunk://#diff-b1007e8dc44028ba8393b0df19d8109dfb96b65cb963c177059e766c3fb6e71aL18-R18))
* Enhanced fallback logic in `MapComponent` to support both `id` and `place_id` when opening Google Maps for a place. (`PlanGo_frontend/src/app/map/map.component.ts`, [PlanGo_frontend/src/app/map/map.component.tsL96-R96](diffhunk://#diff-c70fb41de8d322a2cf4aa898fb0dfa72e7dec3c5779cd1d1969b67d7d9ade6bbL96-R96))
* Improved the fallback mechanism for determining the `primary_type` of a place in `SearchPlacesComponent`. If `primaryType` is unavailable, it now uses the first type from the `types` array if present. (`PlanGo_frontend/src/app/search-places/search-places.component.ts`, [PlanGo_frontend/src/app/search-places/search-places.component.tsL303-R303](diffhunk://#diff-068f7b5d56663f4bd78a9c208117a680ee99727b8bef0e0a87c6e1d7b7cce050L303-R303))