### PR TITLE
refactor: Update no data messages in saved places section to improve clarity

### DIFF
--- a/PlanGo_frontend/src/app/saved-places/saved-places.component.html
+++ b/PlanGo_frontend/src/app/saved-places/saved-places.component.html
@@ -63,7 +63,7 @@
                                 </div>
                                 <div *ngIf="!accommodations || accommodations.length === 0"
                                     class="py-6 text-center text-gray-500">
-                                    No hay alojamientos para mostrar.
+                                    No hay alojamientos guardadas.
                                 </div>
                             </div>
                         </ng-container>
@@ -90,7 +90,7 @@
                                 </div>
                                 <div *ngIf="!restaurants || restaurants.length === 0"
                                     class="py-6 text-center text-gray-500">
-                                    No hay restaurantes para mostrar.
+                                    No hay restaurantes guardadas.
                                 </div>
                             </div>
                         </ng-container>
@@ -117,7 +117,7 @@
                                 </div>
                                 <div *ngIf="!activities || activities.length === 0"
                                     class="py-6 text-center text-gray-500">
-                                    No hay actividades para mostrar.
+                                    No hay actividades guardadas.
                                 </div>
                             </div>
                         </ng-container>


### PR DESCRIPTION
This pull request updates the text displayed in the `saved-places.component.html` file to improve the consistency of phrasing for empty state messages across different categories.

Text consistency improvements:

* Updated the message for accommodations to say "No hay alojamientos guardadas" instead of "No hay alojamientos para mostrar." (`PlanGo_frontend/src/app/saved-places/saved-places.component.html`, [PlanGo_frontend/src/app/saved-places/saved-places.component.htmlL66-R66](diffhunk://#diff-ea2f9a286292c0ae8dc61d8831c2a4b20045c771523ee85c30a1f58409ca16b2L66-R66))
* Updated the message for restaurants to say "No hay restaurantes guardadas" instead of "No hay restaurantes para mostrar." (`PlanGo_frontend/src/app/saved-places/saved-places.component.html`, [PlanGo_frontend/src/app/saved-places/saved-places.component.htmlL93-R93](diffhunk://#diff-ea2f9a286292c0ae8dc61d8831c2a4b20045c771523ee85c30a1f58409ca16b2L93-R93))
* Updated the message for activities to say "No hay actividades guardadas" instead of "No hay actividades para mostrar." (`PlanGo_frontend/src/app/saved-places/saved-places.component.html`, [PlanGo_frontend/src/app/saved-places/saved-places.component.htmlL120-R120](diffhunk://#diff-ea2f9a286292c0ae8dc61d8831c2a4b20045c771523ee85c30a1f58409ca16b2L120-R120))